### PR TITLE
Maven: Work with m2e Plugin and Conventional Improvements

### DIFF
--- a/1.4.7/pom.xml
+++ b/1.4.7/pom.xml
@@ -76,11 +76,41 @@
     <build>
         <defaultGoal>clean package</defaultGoal>
         <finalName>${project.artifactId}</finalName>
+        <sourceDirectory>${project.basedir}/src</sourceDirectory>
         <resources>
             <resource>
                 <directory>${project.basedir}/../resources</directory>
             </resource>
         </resources>
+        <pluginManagement>
+        	<plugins>
+        		<plugin>
+                	<groupId>org.eclipse.m2e</groupId>
+                	<artifactId>lifecycle-mapping</artifactId>
+                	<version>1.0.0</version>
+                	<configuration>
+                    	<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+							            <groupId>com.google.code.maven-replacer-plugin</groupId>
+							            <artifactId>replacer</artifactId>
+							            <versionRange>1.5.1</versionRange>
+							            <goals>
+							            	<goal>replace</goal>
+							            </goals>
+						            </pluginExecutionFilter>
+							          	<action>
+							            	<execute></execute>
+							         	</action>
+							          	<comment>source: </comment>
+						        </pluginExecution>
+	                    	</pluginExecutions>
+                    	</lifecycleMappingMetadata>
+                	</configuration>
+          		</plugin>
+        	</plugins>
+    	</pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>

--- a/1.5.0/pom.xml
+++ b/1.5.0/pom.xml
@@ -76,11 +76,41 @@
     <build>
         <defaultGoal>clean package</defaultGoal>
         <finalName>${project.artifactId}</finalName>
+        <sourceDirectory>${project.basedir}/src</sourceDirectory>
         <resources>
             <resource>
                 <directory>${project.basedir}/../resources</directory>
             </resource>
         </resources>
+        <pluginManagement>
+        	<plugins>
+        		<plugin>
+                	<groupId>org.eclipse.m2e</groupId>
+                	<artifactId>lifecycle-mapping</artifactId>
+                	<version>1.0.0</version>
+                	<configuration>
+                    	<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+							            <groupId>com.google.code.maven-replacer-plugin</groupId>
+							            <artifactId>replacer</artifactId>
+							            <versionRange>1.5.1</versionRange>
+							            <goals>
+							            	<goal>replace</goal>
+							            </goals>
+						            </pluginExecutionFilter>
+							          	<action>
+							            	<execute></execute>
+							         	</action>
+							          	<comment>source: </comment>
+						        </pluginExecution>
+	                    	</pluginExecutions>
+                    	</lifecycleMappingMetadata>
+                	</configuration>
+          		</plugin>
+        	</plugins>
+    	</pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>

--- a/1.5.1/pom.xml
+++ b/1.5.1/pom.xml
@@ -76,11 +76,41 @@
     <build>
         <defaultGoal>clean package</defaultGoal>
         <finalName>${project.artifactId}</finalName>
+        <sourceDirectory>${project.basedir}/src</sourceDirectory>
         <resources>
             <resource>
                 <directory>${project.basedir}/../resources</directory>
             </resource>
         </resources>
+        <pluginManagement>
+        	<plugins>
+        		<plugin>
+                	<groupId>org.eclipse.m2e</groupId>
+                	<artifactId>lifecycle-mapping</artifactId>
+                	<version>1.0.0</version>
+                	<configuration>
+                    	<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+							            <groupId>com.google.code.maven-replacer-plugin</groupId>
+							            <artifactId>replacer</artifactId>
+							            <versionRange>1.5.1</versionRange>
+							            <goals>
+							            	<goal>replace</goal>
+							            </goals>
+						            </pluginExecutionFilter>
+							          	<action>
+							            	<execute></execute>
+							         	</action>
+							          	<comment>source: </comment>
+						        </pluginExecution>
+	                    	</pluginExecutions>
+                    	</lifecycleMappingMetadata>
+                	</configuration>
+          		</plugin>
+        	</plugins>
+    	</pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
Fixed the maven-eclipse-"bug" related to the replacer interfering with the lifecycle feature. (Unknown lifecycle)
https://code.google.com/p/maven-replacer-plugin/issues/detail?id=66

Fixed the pom.xml to actually know where their (unconventional pathed) source is 

http://stackoverflow.com/questions/224373/handling-unconventional-source-directory-for-a-web-project-in-maven
